### PR TITLE
Resolve test registries from child registries of module registries

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+2.2.0 (Unreleased)
+------------------
+
+- Support the correct resolution of test child module registries, which
+  was introduced in ``calmjs-3.3.0``.  [
+  `#6 <https://github.com/calmjs/calmjs.dev/issues/6>`_
+  ]
+
 2.1.0 (2018-05-28)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        'calmjs>=3.1.0,<4',
+        'calmjs>=3.3.0,<4',
         'calmjs.parse>=1.0.0',
     ],
     package_json=package_json,

--- a/src/calmjs/dev/dist.py
+++ b/src/calmjs/dev/dist.py
@@ -5,6 +5,9 @@ Module that provides extra distribution functions
 
 from calmjs.dist import get_module_registry_dependencies
 from calmjs.dist import TEST_REGISTRY_NAME_SUFFIX
+from calmjs.base import BaseModuleRegistry
+from calmjs.module import resolve_child_module_registries_lineage
+from calmjs.registry import get
 
 
 def get_module_registries_dependencies(
@@ -29,6 +32,14 @@ def map_registry_name_to_test(
     """
 
     for registry_name in registry_names:
+        registry = get(registry_name)
+        if isinstance(registry, BaseModuleRegistry):
+            it = resolve_child_module_registries_lineage(registry)
+            prefix = next(it).registry_name
+            suffix = registry.registry_name[len(prefix):]
+            yield prefix + test_registry_name_suffix + suffix
+            continue
+        # no assumptions about whether these registries actually exists
         yield registry_name + test_registry_name_suffix
 
 

--- a/src/calmjs/dev/tests/test_dist.py
+++ b/src/calmjs/dev/tests/test_dist.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 import unittest
 
+from calmjs import base
 from calmjs.dev import dist
+from calmjs.testing.utils import stub_item_attr_value
+from calmjs.testing.mocks import WorkingSet
+from calmjs.testing.module import ChildModuleRegistry
 
 
 class DistTestCase(unittest.TestCase):
@@ -24,3 +28,31 @@ class DistTestCase(unittest.TestCase):
             'calmjs/dev/tests/test_fail',
             'calmjs/dev/tests/test_main',
         ])
+
+    def test_map_registry_name_to_test(self):
+        working_set = WorkingSet({})
+        root = base.BaseModuleRegistry(
+            'root.module', _working_set=working_set)
+        child = ChildModuleRegistry(
+            'root.module.child', _parent=root, _working_set=working_set)
+        grandchild = ChildModuleRegistry(
+            'root.module.child.child', _parent=child,
+            _working_set=working_set)
+
+        stub_item_attr_value(self, dist, 'get', {
+            r.registry_name: r for r in [root, child, grandchild]}.get)
+
+        # no assumptions are made about missing registries
+        self.assertEqual([
+            'missing.module.child.tests',
+        ], list(dist.map_registry_name_to_test(['missing.module.child'])))
+
+        # standard registry
+        self.assertEqual([
+            'root.module.tests',
+        ], list(dist.map_registry_name_to_test(['root.module'])))
+
+        # grandchild registry
+        self.assertEqual([
+            'root.module.tests.child.child',
+        ], list(dist.map_registry_name_to_test(['root.module.child.child'])))


### PR DESCRIPTION
Support the resolution of `BaseChildModuleRegistry` to the intended test registry name, as it cannot be naively have the `.tests` suffix appended but it should also reference a parent `BaseModuleRegistry` that has the `.tests` suffix appended (thus all the child must have further suffixes after `.tests` which is what this change supports).