### PR TITLE
Missing karma binary should fail correctly

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+2.2.0 (Unreleased)
+------------------
+
+- Ensure that a missing karma binary is also correctly dealt with by the
+  same set of exception and flags.  [
+  `#7 <https://github.com/calmjs/calmjs.dev/issues/7>`_
+  ]
+
 2.1.0 (2018-05-28)
 ------------------
 

--- a/src/calmjs/dev/cli.py
+++ b/src/calmjs/dev/cli.py
@@ -108,7 +108,10 @@ class KarmaDriver(NodeDriver):
         # For now at least log this down like so.
         binary = self.which() or self.which_with_node_modules()
         if binary is None:
-            raise AdviceAbort('karma not found')
+            if spec.get(karma.KARMA_ABORT_ON_TEST_FAILURE):
+                raise ToolchainAbort('karma not found')
+            else:
+                raise AdviceAbort('karma not found')
         # but actually run it with the '--color' flag, because otherwise
         # colors don't work consistently... Node.js tools in a nutshell.
         # ... at least disable colours in the config file will also make


### PR DESCRIPTION
Ensure that when running tests using `calmjs karma`, that if the `karma` binary is not available the test fail in the same manner as per the abort on test failure flag.