### PR TITLE
Provide the ability to customise configuration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+2.2.1 (Unreleased)
+------------------
+
+- Allow the karma configuration writer to be specified in the spec, such
+  that it may be overridden by framework integration packages.  [
+  `#8 <https://github.com/calmjs/calmjs.dev/issues/8>`_
+  ]
+
 2.2.0 (2018-07-24)
 ------------------
 

--- a/src/calmjs/dev/cli.py
+++ b/src/calmjs/dev/cli.py
@@ -313,8 +313,18 @@ class KarmaDriver(NodeDriver):
         build_dir = spec[BUILD_DIR]
         config_fn = join(build_dir, self.karma_conf_js)
         with open(config_fn, 'w') as fd:
-            writer = spec.get(karma.KARMA_CONFIG_WRITER, partial(
-                karma.config_writer, self))
+            if karma.KARMA_CONFIG_WRITER in spec:
+                writer = spec[karma.KARMA_CONFIG_WRITER]
+                logger.debug(
+                    "writing karma configuration file to '%s' with writer "
+                    "that was assigned to spec[KARMA_CONFIG_WRITER]", config_fn
+                )
+            else:
+                writer = partial(karma.config_writer, self)
+                logger.debug(
+                    "writing karma configuration file to '%s' with default "
+                    "karma configuration writer", config_fn
+                )
             writer(karma_config, fd)
         return config_fn
 

--- a/src/calmjs/dev/cli.py
+++ b/src/calmjs/dev/cli.py
@@ -5,6 +5,7 @@ This module provides interface to the karma cli runtime.
 
 import logging
 import re
+from functools import partial
 from os.path import exists
 from os.path import join
 from os.path import realpath
@@ -309,11 +310,12 @@ class KarmaDriver(NodeDriver):
                 files.extend(f)
         karma_config['files'] = files
 
-        s = self.dumps(karma_config)
         build_dir = spec[BUILD_DIR]
         config_fn = join(build_dir, self.karma_conf_js)
         with open(config_fn, 'w') as fd:
-            fd.write(karma.KARMA_CONF_TEMPLATE % s)
+            writer = spec.get(karma.KARMA_CONFIG_WRITER, partial(
+                karma.config_writer, self))
+            writer(karma_config, fd)
         return config_fn
 
     def write_config(self, spec):

--- a/src/calmjs/dev/karma.py
+++ b/src/calmjs/dev/karma.py
@@ -19,6 +19,7 @@ KARMA_ADVICE_GROUP = 'karma_advice_group'
 KARMA_BROWSERS = 'karma_browsers'
 KARMA_CONFIG = 'karma_config'
 KARMA_CONFIG_PATH = 'karma_config_path'
+KARMA_CONFIG_WRITER = 'karma_config_writer'
 KARMA_EXTRA_FRAMEWORKS = 'karma_extra_frameworks'
 KARMA_RETURN_CODE = 'karma_return_code'
 KARMA_SPEC_KEYS = 'karma_spec_keys'
@@ -133,3 +134,30 @@ def build_coverage_reporters_config(report_keys, report_dir, report_file):
         'dir': report_dir,
         'reporters': reporters,
     }
+
+
+def config_writer(driver, config, fd):
+    """
+    The default complete karma config writer.  Note that the invocation
+    of the writer by the ``cli.KarmaDriver`` class only applies the
+    latter two arguments, and it would construct a partial using itself
+    to do so.
+
+    The writer itself may be override by providing a function that takes
+    two arguments to spec[KARMA_CONFIG_WRITER], and it may be a partial
+    so that the values of spec and/or the toolchain (plus others) may be
+    referenced from within the scope of the writer, for example:
+
+        from functools import partial
+
+        def some_writer(toolchain, spec, config, fd):
+            fd.write(toolchain.process_test_config(spec, config))
+
+        spec[KARMA_CONFIG_WRITER] = partial(some_writer, toolchain, spec)
+
+    Naturally, the contents written must call config.set with the valid
+    karma configuration settings in order for the execution of the test
+    to occur correctly.
+    """
+
+    fd.write(KARMA_CONF_TEMPLATE % driver.dumps(config))

--- a/src/calmjs/dev/tests/test_cli.py
+++ b/src/calmjs/dev/tests/test_cli.py
@@ -701,5 +701,22 @@ class KarmaDriverTestSpecTestCase(unittest.TestCase):
         self.assertIn('test/file', conf)
         self.assertIn('test/artifact', conf)
 
+    def test_write_config_override(self):
+        def config_writer(karma_config, fd):
+            karma_config['foo'] = 'bar'
+            fd.write(json.dumps(karma_config))
+
+        build_dir = mkdtemp(self)
+        spec = Spec(
+            build_dir=build_dir, karma_config={},
+            karma_config_writer=config_writer,
+        )
+        driver = cli.KarmaDriver()
+        driver.write_config(spec)
+        # naturally, this is NOT a valid karma.conf.js since what was
+        # written is just an ordinary JSON file.
+        with open(join(build_dir, 'karma.conf.js')) as fd:
+            self.assertEqual({'files': [], 'foo': 'bar'}, json.load(fd))
+
 # rest of cli related tests have been streamlined into runtime for
 # setup and teardown optimisation.

--- a/src/calmjs/dev/tests/test_cli.py
+++ b/src/calmjs/dev/tests/test_cli.py
@@ -695,8 +695,14 @@ class KarmaDriverTestSpecTestCase(unittest.TestCase):
             build_dir=build_dir, karma_config={'files': ['test/file']},
             artifact_paths=['test/artifact'],
         )
-        driver.write_config(spec)
-        with open(join(build_dir, 'karma.conf.js')) as fd:
+        with pretty_logging(
+                logger='calmjs.dev', stream=mocks.StringIO()) as log:
+            driver.write_config(spec)
+        karma_conf_js = join(build_dir, 'karma.conf.js')
+        self.assertIn(
+            "' with default karma configuration writer", log.getvalue())
+        self.assertIn(karma_conf_js, log.getvalue())
+        with open(karma_conf_js) as fd:
             conf = fd.read()
         self.assertIn('test/file', conf)
         self.assertIn('test/artifact', conf)
@@ -712,10 +718,16 @@ class KarmaDriverTestSpecTestCase(unittest.TestCase):
             karma_config_writer=config_writer,
         )
         driver = cli.KarmaDriver()
-        driver.write_config(spec)
+        with pretty_logging(
+                logger='calmjs.dev', stream=mocks.StringIO()) as log:
+            driver.write_config(spec)
+        karma_conf_js = join(build_dir, 'karma.conf.js')
+        self.assertIn("' with writer", log.getvalue())
+        self.assertIn(karma_conf_js, log.getvalue())
+
         # naturally, this is NOT a valid karma.conf.js since what was
         # written is just an ordinary JSON file.
-        with open(join(build_dir, 'karma.conf.js')) as fd:
+        with open(karma_conf_js) as fd:
             self.assertEqual({'files': [], 'foo': 'bar'}, json.load(fd))
 
 # rest of cli related tests have been streamlined into runtime for


### PR DESCRIPTION
- This is achieved by providing a new spec key and the assignment of a
  writer function to it.  The function must accept the configuration
  dict and a stream object.