### PR TITLE
Loosen karma config check

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+2.2.2 (2018-??-??)
+------------------
+
+- Permit the use of other karma_conf dict/mapping types in the spec.  [
+  `#9 <https://github.com/calmjs/calmjs.dev/issues/9>`_
+  ]
+
 2.2.1 (2018-08-01)
 ------------------
 

--- a/src/calmjs/dev/cli.py
+++ b/src/calmjs/dev/cli.py
@@ -296,9 +296,9 @@ class KarmaDriver(NodeDriver):
     def _write_config(self, spec):
         # grab the config from the spec.
         karma_config = spec.get(karma.KARMA_CONFIG)
-        if not isinstance(karma_config, dict):
+        if karma_config is None:
             logger.error(
-                "no valid '%s' in spec; cannot write '%s'",
+                "'%s' not present in spec; cannot write '%s'",
                 karma.KARMA_CONFIG, self.karma_conf_js,
             )
             return

--- a/src/calmjs/dev/tests/test_cli.py
+++ b/src/calmjs/dev/tests/test_cli.py
@@ -659,7 +659,7 @@ class KarmaDriverTestSpecTestCase(unittest.TestCase):
                 logger='calmjs.dev', stream=mocks.StringIO()) as log:
             driver.write_config(spec)
         self.assertIn(
-            "no valid 'karma_config' in spec; cannot write 'karma.conf.js'",
+            "'karma_config' not present in spec; cannot write 'karma.conf.js'",
             log.getvalue(),
         )
         self.assertFalse(exists(join(build_dir, 'karma.conf.js')))


### PR DESCRIPTION
These changes permit the use of alternative mapping types, to allow more effective use case when the custom writer function is specified in conjunction of a custom class.