### PR TITLE
Pass the NODE_PATH of the environment that karma is in to the config file context

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+2.2.2 (2018-??-??)
+------------------
+
+- Configuration writers that write out karma configuration scripts that
+  import other Node.js modules that are present within the environment
+  that the karma binary reside in should no longer encounter a ``Error:
+  Cannot find module`` message.  [
+  `#10 <https://github.com/calmjs/calmjs.dev/issues/10>`_
+  ]
+
 2.2.1 (2018-08-01)
 ------------------
 

--- a/src/calmjs/dev/cli.py
+++ b/src/calmjs/dev/cli.py
@@ -33,6 +33,7 @@ from calmjs.toolchain import dict_update_overwrite_check
 
 from calmjs.cli import NodeDriver
 from calmjs.cli import get_bin_version
+from calmjs.cli import get_node_version
 
 from calmjs.dev import dist
 from calmjs.dev import karma
@@ -60,6 +61,14 @@ from calmjs.dev.toolchain import prepare_spec_artifacts
 from calmjs.dev.toolchain import update_spec_for_karma
 
 logger = logging.getLogger(__name__)
+
+
+def warn_if_nodejs_lt_6(*a, **kw):
+    version = get_node_version()
+    # can't do anything if version is not found
+    if version is None or version >= (6,):
+        return
+    logger.warning(*a, **kw)
 
 
 class KarmaDriver(NodeDriver):
@@ -318,6 +327,12 @@ class KarmaDriver(NodeDriver):
                 logger.debug(
                     "writing karma configuration file to '%s' with writer "
                     "that was assigned to spec[KARMA_CONFIG_WRITER]", config_fn
+                )
+                warn_if_nodejs_lt_6(
+                    "custom karma config writer specified with spec; if "
+                    "an 'Invalid config file' or 'Error: cannot find "
+                    "module' message results, please upgrade Node.js to "
+                    "version 6 or above.",
                 )
             else:
                 writer = partial(karma.config_writer, self)

--- a/src/calmjs/dev/cli.py
+++ b/src/calmjs/dev/cli.py
@@ -100,7 +100,7 @@ class KarmaDriver(NodeDriver):
         spec.handle(karma.BEFORE_KARMA)
 
         config_fn = join(spec[BUILD_DIR], self.karma_conf_js)
-        call_kw = self._gen_call_kws(**utils.extract_gui_environ_keys())
+        call_kw = self._gen_call_kws(**utils.karma_environ(self))
         logger.info('invoking %s start %r', self.binary, config_fn)
         # TODO would be great if there is a way to "tee" the result into
         # both here and stdout.

--- a/src/calmjs/dev/tests/test_runtime.py
+++ b/src/calmjs/dev/tests/test_runtime.py
@@ -20,6 +20,7 @@ from pkg_resources import WorkingSet
 from calmjs.parse import es5
 from calmjs.artifact import ArtifactRegistry
 from calmjs.argparse import ArgumentParser
+from calmjs.cli import get_node_version
 from calmjs.exc import ToolchainAbort
 from calmjs.npm import get_npm_version
 from calmjs.npm import Driver as NPMDriver
@@ -59,6 +60,7 @@ from calmjs.testing.utils import stub_mod_call
 from calmjs.testing.utils import stub_stdouts
 
 npm_version = get_npm_version()
+node_version = get_node_version()
 
 
 class TestCommonArgparser(unittest.TestCase):
@@ -462,6 +464,9 @@ class CliRuntimeTestCase(unittest.TestCase):
         # as no abort registered.
         self.driver.run(toolchain, spec)
 
+    @unittest.skipIf(
+        node_version is None or node_version < (6,),
+        'feature not supported by environment Node.js version')
     def test_manual_config_writer_with_require(self):
         # ensure that custom writers that writes out a script to include
         # imports of Node.js modules (e.g. assistance with generation of

--- a/src/calmjs/dev/tests/test_runtime.py
+++ b/src/calmjs/dev/tests/test_runtime.py
@@ -41,6 +41,7 @@ from calmjs.dev.toolchain import prepare_spec_artifacts
 from calmjs.dev.toolchain import update_spec_for_karma
 from calmjs.dev.artifact import ArtifactTestRegistry
 from calmjs.dev.karma import DEFAULT_COVER_REPORT_TYPE_OPTIONS
+from calmjs.dev.karma import KARMA_CONF_TEMPLATE
 from calmjs.dev.runtime import init_argparser_common
 from calmjs.dev.runtime import KarmaRuntime
 from calmjs.dev.runtime import TestToolchainRuntime
@@ -460,6 +461,37 @@ class CliRuntimeTestCase(unittest.TestCase):
         toolchain = NullToolchain()
         # as no abort registered.
         self.driver.run(toolchain, spec)
+
+    def test_manual_config_writer_with_require(self):
+        # ensure that custom writers that writes out a script to include
+        # imports of Node.js modules (e.g. assistance with generation of
+        # the final configuration file) will work as expected.
+
+        def config_writer(config, fd):
+            # lodash module is part of the karma dependency
+            fd.write('require("lodash");\n')
+            fd.write(KARMA_CONF_TEMPLATE % json.dumps(config))
+
+        main = resource_filename('calmjs.dev', 'main.js')
+        test_main = resource_filename('calmjs.dev.tests', 'test_main.js')
+        spec = Spec(
+            # null toolchain does not prepare this
+            transpile_sourcepath={
+                'calmjs/dev/main': main,
+            },
+            test_module_paths_map={
+                'calmjs/test_main': test_main,
+            },
+            karma_config_writer=config_writer,
+        )
+        toolchain = NullToolchain()
+        self.driver.run(toolchain, spec)
+        # do note that while this succeeds, the failure condition from
+        # the lack of code in this related changeset is NOT guarantee,
+        # as it is possible for the top level directory or some other
+        # global node modules environment to provide lodash.
+        self.assertEqual(spec['karma_return_code'], 0)
+        self.assertIn('link', spec)
 
     # Now we have the proper runtime tests.
 

--- a/src/calmjs/dev/utils.py
+++ b/src/calmjs/dev/utils.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
+from os.path import pathsep
 from itertools import chain
 
 
@@ -21,6 +22,12 @@ _GUI_EXEC_KEYS = [
 
 def extract_gui_environ_keys(keys=_GUI_EXEC_KEYS):
     return {key: os.environ[key] for key in keys if key in os.environ}
+
+
+def karma_environ(driver):
+    base_keys = extract_gui_environ_keys()
+    base_keys['NODE_PATH'] = pathsep.join(driver.find_node_modules_basedir())
+    return base_keys
 
 
 def get_toolchain_targets_keys(


### PR DESCRIPTION
This is so that any customised `karma.conf.js` that get generated to include `require` statements to other Node.js module will function as expected.